### PR TITLE
[feature] Support writing flow as numpy array (closes #20)

### DIFF
--- a/src/flowty/cli.py
+++ b/src/flowty/cli.py
@@ -9,7 +9,7 @@ flow_method_base_parser.add_argument(
 )
 flow_method_base_parser.add_argument(
     "dest",
-    type=Path,
+    type=str,
     help="Path to video output, e.g. /data/flow/{axis}/frame_{:06d}.jpg",
 )
 flow_method_base_parser.add_argument(

--- a/src/flowty/flow_command.py
+++ b/src/flowty/flow_command.py
@@ -1,11 +1,9 @@
 from abc import ABC
 
 from flowty.cv import mat_to_array
-from flowty.cv.cuda import get_cuda_enabled_device_count
 from flowty.cv.videoio import VideoSource
 from flowty.flow_pipe import FlowPipe
-from flowty.imgproc import quantise_flow
-from flowty.videoio import FlowImageWriter
+from flowty.videoio import get_flow_writer
 
 
 class AbstractFlowCommand(ABC):
@@ -15,7 +13,7 @@ class AbstractFlowCommand(ABC):
         self.video_src = VideoSource(
                 str(args.src.absolute()), backend=args.opencv_videoio_backend
         )
-        self.video_sink = FlowImageWriter(str(args.dest))
+        self.video_sink = get_flow_writer(args)
         self.flow_algorithm = self.get_flow_algorithm(args)
 
     def get_flow_algorithm(self, args):
@@ -31,7 +29,7 @@ class AbstractFlowCommand(ABC):
                 src=self.video_src,
                 flow_algorithm=self.flow_algorithm,
                 dest=self.video_sink,
-                output_transforms=[mat_to_array, quantise_flow],
+                output_transforms=[mat_to_array],
                 stride=self.args.video_stride,
                 dilation=self.args.video_dilation,
         )

--- a/src/flowty/videoio.py
+++ b/src/flowty/videoio.py
@@ -1,35 +1,74 @@
+import argparse
 from pathlib import Path
 import numpy as np
 
+from flowty.imgproc import quantise_flow
 from .cv.imgcodecs import imwrite
 
 
-class FlowImageWriter:
-    def __init__(self, file_path_template: str):
+def get_flow_writer(args: argparse.Namespace):
+    extension_writer_map = [
+        (['jpeg', 'jpg', 'png'], FlowUVImageWriter),
+        (['np', 'npy'], FlowNumpyWriter)
+    ]
+    for extensions, writer_cls in extension_writer_map:
+        for extension in extensions:
+            if args.dest.lower().endswith('.' + extension):
+                return writer_cls(args.dest)
+    else:
+        raise ValueError("Unable to retrieve flow writer for '{}'".format(
+                args.dest))
+
+
+class FlowUVImageWriter:
+    def __init__(self, file_path_template: str, bound=20):
         self.file_path_template = file_path_template
         self.frame_index = 1
+        self.bound = bound
 
-    def __call__(self, flow: np.ndarray):
+    def write(self, flow: np.ndarray) -> None:
         if flow.ndim != 3:
             raise ValueError("Expected flow to be 3D, but was {}D".format(flow.ndim))
         if flow.shape[2] != 2:
             raise ValueError("Expected flow to have 2 channels, but had {}".format(flow.shape[2]))
-        if flow.dtype != np.uint8:
-            raise ValueError("Expected flow to be np.uint8, but was {}".format(flow.dtype))
+
+        quantised_flow = quantise_flow(flow, bound=self.bound)
+        self._write_uv_images(quantised_flow)
+        self.frame_index += 1
+
+    def _write_uv_images(self, flow: np.ndarray) -> None:
         u_img_path = self.file_path_template.format(
-            axis='u',
-            index=self.frame_index
+                axis='u',
+                index=self.frame_index
         )
         v_img_path = self.file_path_template.format(
-            axis='v',
-            index=self.frame_index
+                axis='v',
+                index=self.frame_index
         )
         for dest in [u_img_path, v_img_path]:
             Path(dest).parent.mkdir(exist_ok=True, parents=True)
         imwrite(u_img_path, flow[..., 0])
         imwrite(v_img_path, flow[..., 1])
 
+
+class FlowNumpyWriter:
+    def __init__(self, file_path_template: str):
+        self.file_path_template = file_path_template
+        self.frame_index = 1
+
+    def write(self, flow: np.ndarray) -> None:
+        if flow.ndim != 3:
+            raise ValueError("Expected flow to be 3D, but was {}D".format(flow.ndim))
+        if flow.shape[2] != 2:
+            raise ValueError("Expected flow to have 2 channels, but had {}".format(flow.shape[2]))
+
+        self._write_flow(flow)
+
         self.frame_index += 1
 
-    def write(self, flow: np.ndarray):
-        return self(flow)
+    def _write_flow(self, flow: np.ndarray) -> None:
+        filepath = Path(self.file_path_template.format(index=self.frame_index))
+        filepath.parent.mkdir(exist_ok=True, parents=True)
+        with filepath.open(mode='wb') as f:
+            np.save(f, flow)
+

--- a/tests/functional/io/writers/test_flow_writer.py
+++ b/tests/functional/io/writers/test_flow_writer.py
@@ -1,42 +1,89 @@
+import argparse
 from pathlib import Path
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
-from flowty.videoio import FlowImageWriter
+from flowty.videoio import FlowUVImageWriter, FlowNumpyWriter, get_flow_writer
 
 
-class TestFlowImageWriter:
+class TestGetFlowWriter:
+    @pytest.mark.parametrize("extension", ["jpg", "jpeg", "JPEG", "png", "PNG"])
+    def test_image_extensions_returns_flow_uv_writer(self, extension):
+        writer = get_flow_writer(self.create_args(extension))
+        assert isinstance(writer, FlowUVImageWriter)
+
+    @pytest.mark.parametrize("extension", ["npy", "np", "NPY"])
+    def test_npy_returns_flow_numpy_writer(self, extension):
+        writer = get_flow_writer(self.create_args(extension))
+        assert isinstance(writer, FlowNumpyWriter)
+
+    def test_raises_error_on_unknown_extension(self):
+        with pytest.raises(ValueError):
+            get_flow_writer(self.create_args("asdf"))
+
+    def create_args(self, extension: str) -> argparse.Namespace:
+        args = argparse.Namespace()
+        args.dest = "path/{axis}/frame_{index:05d}." + extension
+        return args
+
+
+class TestFlowUVImageWriter:
     def test_saving_single_flow_image(self, tmp_path):
         image_writer = self.get_flow_writer(tmp_path)
-        flow = np.random.randint(low=0, high=255, size=(5, 5, 2), dtype=np.uint8)
-
+        flow = np.random.uniform(low=-20, high=20, size=(5, 5, 2))
         image_writer.write(flow)
 
         for axis in ['u', 'v']:
             assert (Path(tmp_path) / axis / '00001.jpg').exists()
 
-    def test_throws_error_if_flow_not_uint8(self, tmp_path):
-        image_writer = self.get_flow_writer(tmp_path)
-        flow = np.random.randint(low=0, high=255, size=(5, 5, 2), dtype=np.int32)
-
-        with pytest.raises(ValueError):
-            image_writer.write(flow)
-
     def test_throws_error_if_flow_not_2_channels(self, tmp_path):
         image_writer = self.get_flow_writer(tmp_path)
-        flow = np.random.randint(low=0, high=255, size=(5, 5, 3), dtype=np.uint8)
+        flow = np.random.uniform(low=-20, high=20, size=(5, 5, 3))
 
         with pytest.raises(ValueError):
             image_writer.write(flow)
 
     def test_throws_error_if_flow_not_3_dimensional(self, tmp_path):
         image_writer = self.get_flow_writer(tmp_path)
-        flow = np.random.randint(low=0, high=255, size=(5, 5), dtype=np.uint8)
+        flow = np.random.uniform(low=-20, high=20, size=(5, 5))
 
         with pytest.raises(ValueError):
             image_writer.write(flow)
 
     def get_flow_writer(self, tmp_path):
         filename_template = tmp_path / '{axis}/{index:05d}.jpg'
-        return FlowImageWriter(str(filename_template))
+        return FlowUVImageWriter(str(filename_template))
+
+
+class TestFlowNumpyWriter:
+    def test_saving_single_flow_field(self, tmp_path):
+        writer = self.get_flow_writer(tmp_path)
+
+        flow = np.random.uniform(low=-20, high=20, size=(5, 5, 2))
+
+        writer.write(flow)
+
+        expect_flow_file = Path(tmp_path / 'frame_00001.npy')
+        assert expect_flow_file.exists()
+        loaded_flow = np.load(expect_flow_file)
+        assert_array_equal(loaded_flow, flow)
+
+    def test_raises_error_if_flow_not_3_dimensional(self, tmp_path):
+        writer = self.get_flow_writer(tmp_path)
+        flow = np.random.uniform(low=-20, high=20, size=(5, 5))
+
+        with pytest.raises(ValueError):
+            writer.write(flow)
+
+    def test_raises_error_if_flow_not_2_channel(self, tmp_path):
+        writer = self.get_flow_writer(tmp_path)
+        flow = np.random.uniform(low=-20, high=20, size=(5, 5, 3))
+
+        with pytest.raises(ValueError):
+            writer.write(flow)
+
+    def get_flow_writer(self, tmp_path):
+        filename_template = tmp_path / 'frame_{index:05d}.npy'
+        return FlowNumpyWriter(str(filename_template))

--- a/tests/unit/algorithms/test_brox.py
+++ b/tests/unit/algorithms/test_brox.py
@@ -19,7 +19,7 @@ class TestBroxFlowCommand:
         ("scale-factor", "scale_factor", 0.5),
     ])
     def test_cpu_args(self, arg, attr, value):
-        str_args = ["brox", "src", "dest", "--{}".format(arg), str(value)]
+        str_args = ["brox", "src", "flow/{axis}/frame_{index:05d}.jpg", "--{}".format(arg), str(value)]
 
         flow_alg = self.get_flow_alg(str_args)
 
@@ -41,5 +41,5 @@ class TestBroxFlowCommand:
         with monkeypatch.context() as ctx:
             ctx.setattr(flowty, "cuda_available", False)
             with pytest.raises(RuntimeError):
-                self.get_flow_alg(["brox", "src", "dest"])
+                self.get_flow_alg(["brox", "src", "flow/{axis}/frame_{index:05d}.jpg"])
 

--- a/tests/unit/algorithms/test_dis.py
+++ b/tests/unit/algorithms/test_dis.py
@@ -31,7 +31,7 @@ class TestDenseInverseSearchCommand:
         else:
             cli_value = value
             instance_value = value
-        str_args = ["dis", "src", "dest", "--preset", "medium", "--{}".format(arg)] + (
+        str_args = ["dis", "src", "flow/{axis}/frame_{index:05d}.jpg", "--preset", "medium", "--{}".format(arg)] + (
             [str(cli_value)] if cli_value is not None else []
         )
 

--- a/tests/unit/algorithms/test_farneback.py
+++ b/tests/unit/algorithms/test_farneback.py
@@ -27,7 +27,7 @@ class TestFarnebackCommand:
             cli_value = value
             instance_value = value
         str_args = (
-            ["farneback", "src", "dest", "--{}".format(arg)]
+            ["farneback", "src", "flow/{axis}/frame_{index:05d}.jpg", "--{}".format(arg)]
             + ([str(cli_value)] if cli_value is not None else [])
         )
 
@@ -49,7 +49,7 @@ class TestFarnebackCommand:
             cli_value = value
             instance_value = value
         str_args = (
-                ["farneback", "src", "dest", "--{}".format(arg)]
+                ["farneback", "src", "flow/{axis}/frame_{index:05d}.jpg", "--{}".format(arg)]
                 + ([str(cli_value)] if cli_value is not None else [])
                 + ["--cuda"]
         )

--- a/tests/unit/algorithms/test_pyrlk.py
+++ b/tests/unit/algorithms/test_pyrlk.py
@@ -18,7 +18,7 @@ class TestPyramidalLucasKanadeCommand:
     )
     def test_args(self, arg, attr, value):
         str_args = (
-            ["pyrlk", "src", "dest", "--{}".format(arg)]
+            ["pyrlk", "src", "flow/{axis}/frame_{index:05d}.jpg", "--{}".format(arg)]
             + ([str(value)] if value is not None else [])
         )
 

--- a/tests/unit/algorithms/test_tvl1.py
+++ b/tests/unit/algorithms/test_tvl1.py
@@ -24,7 +24,7 @@ class TestTvL1FlowCommand:
         ("median-filtering", "median_filtering", 2),
     ])
     def test_cpu_args(self, arg, attr, value):
-        str_args = ["tvl1", "src", "dest", "--{}".format(arg), str(value)]
+        str_args = ["tvl1", "src", "flow/{axis}/frame_{index:05d}.jpg", "--{}".format(arg), str(value)]
 
         flow_alg = self.get_flow_alg(str_args)
 
@@ -54,7 +54,7 @@ class TestTvL1FlowCommand:
         ("scale-step", "scale_step", 0.7),
     ])
     def test_gpu_args(self, arg, attr, value):
-        str_args = ["tvl1", "src", "dest", "--{}".format(arg), str(value), "--cuda"]
+        str_args = ["tvl1", "src", "flow/{axis}/frame_{index:05d}.jpg", "--{}".format(arg), str(value), "--cuda"]
 
         flow_alg = self.get_flow_alg(str_args)
 
@@ -67,7 +67,7 @@ class TestTvL1FlowCommand:
     def test_gpu_iterations(self):
         inner_iterations = 20
         outer_iterations = 30
-        str_args = ["tvl1", "src", "dest", "--inner-iterations", str(inner_iterations),
+        str_args = ["tvl1", "src", "flow/{axis}/frame_{index:05d}.jpg", "--inner-iterations", str(inner_iterations),
                     "--outer-iterations", str(outer_iterations), "--cuda"]
 
         flow_alg = self.get_flow_alg(str_args)
@@ -77,7 +77,7 @@ class TestTvL1FlowCommand:
 
     @pytest.mark.skipif('not flowty.cuda_available')
     def test_median_filtering_on_gpu_raises_error(self):
-        str_args = ["tvl1", "src", "dest", "--median-filtering", "3", "--cuda"]
+        str_args = ["tvl1", "src", "flow/{axis}/frame_{index:05d}.jpg", "--median-filtering", "3", "--cuda"]
 
         with pytest.raises(ValueError):
             self.get_flow_alg(str_args)
@@ -86,4 +86,4 @@ class TestTvL1FlowCommand:
         with monkeypatch.context() as ctx:
             ctx.setattr(flowty, "cuda_available", False)
             with pytest.raises(RuntimeError):
-                self.get_flow_alg(["tvl1", "src", "dest", "--cuda"])
+                self.get_flow_alg(["tvl1", "src", "flow/{axis}/frame_{index:05d}.jpg", "--cuda"])

--- a/tests/unit/algorithms/test_vr.py
+++ b/tests/unit/algorithms/test_vr.py
@@ -21,7 +21,7 @@ class TestVariationalRefinmentCommand:
     )
     def test_args(self, arg, attr, value):
         str_args = (
-            ["vr", "src", "dest", "--{}".format(arg)]
+            ["vr", "src", "flow/{axis}/frame_{index:05d}.jpg", "--{}".format(arg)]
             + ([str(value)] if value is not None else [])
         )
 


### PR DESCRIPTION
Numpy arrays can now be saved by specifying a `dest` with a `.np` or
`.npy` extension.

Example invocation:

```
$ flowty dis media/rubber-whale.mp4 flow/frame_{index:02d}.npy
```